### PR TITLE
Change Hue and Saturation set order

### DIFF
--- a/index.js
+++ b/index.js
@@ -421,11 +421,11 @@ function makeThing(log, config) {
             if (config.topics.setBrightness) {
                 characteristic_Brightness(service);
             }
-            if (config.topics.setHue) {
-                characteristic_Hue(service);
-            }
             if (config.topics.setSaturation) {
                 characteristic_Saturation(service);
+            }
+            if (config.topics.setHue) {
+                characteristic_Hue(service);
             }
         } else if (config.type == "switch") {
             service = new Service.Switch(name);


### PR DESCRIPTION
Change Hue and Saturation set order to prevent error on RGB conversion.
If your HSL is stored as RGB then changing the Hue when saturation is zero is useless. So it changes the saturation first and then the Hue.

It's useful when processing single MQTT messages at a time and storing your light value as RGB.