### PR TITLE
Allow applying functions to get/set... mqtt messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,24 @@ The following settings apply to all device types:
 
 `getName` - Topic that may be published to send HomeKit the name of the accessory (optional)
 
+### Applying functions to mqtt messages
+
+If a mqtt message is not a simple value or does not match the expected syntax, it is possible to specify a javascript function that is called for the message every time it is received/published. For this, the topic string in the configuration can be replaced with an object with these properties:
+
+`topic` - Topic string
+
+`apply` - Javascript function to apply (must be a complete function body that `return`s a value). The function is called with one argument: the original message. (optional)
+
+e.g.
+```javascript
+  "topics": {
+      "getCurrentTemperature": {
+          "topic": "outdoor",
+          "apply": "return JSON.parse(message).temperature.toFixed(1);"
+      }
+  }
+```
+
 ### Boolean Value Settings
 
 Homekit Boolean types like on/off use strings "true" and "false" in MQTT messages unless `"integerValue": true` is configured, in which case they use to "1" and "0". Alternatively, specific values can be configured using `onValue` and `offValue` (in which case `integerValue` is ignored). Other Homekit types (integer, string, etc.) are not affected by these settings.

--- a/index.js
+++ b/index.js
@@ -77,6 +77,17 @@ function makeThing(log, config) {
     var mqttClient = mqttInit();
 
     function mqttSubscribe(topic, handler) {
+        if (typeof topic != 'string') {          
+            var extendedTopic = topic;
+            topic = extendedTopic['topic'];
+            if (extendedTopic.hasOwnProperty('apply')) {
+                var previous = handler;
+                var applyFn = Function("message", extendedTopic['apply']);
+                handler = function (topic, message) {
+                    return previous(topic, applyFn(message));
+                };
+            }
+        }    
         if( mqttDispatch.hasOwnProperty( topic ) ) {
             // new handler for existing topic
             mqttDispatch[ topic ].push( handler );

--- a/index.js
+++ b/index.js
@@ -99,6 +99,14 @@ function makeThing(log, config) {
     }
 
     function mqttPublish(topic, message) {
+        if (typeof topic != 'string') {          
+            var extendedTopic = topic;
+            topic = extendedTopic['topic'];
+            if (extendedTopic.hasOwnProperty('apply')) {
+                var applyFn = Function("message", extendedTopic['apply']);
+                message = applyFn(message);
+            }
+        }    
         if( logmqtt ) {
             log( 'Publishing MQTT: ' + topic + ' = ' + message );
         }


### PR DESCRIPTION
I use this to interface my JSON-speaking  devices, e.g.:
```
        {
            "accessory": "mqttthing",
            "type": "fan",
            "name": "Bedroom fan",
            "url": "http://mqtt:1883/",
            "topics": {
                "getRotationSpeed": {
                    "topic": "fan/bedroom/fan",
                    "apply": "return JSON.parse(message).speed;"
                },
                "setRotationSpeed": {
                    "topic": "fan/bedroom/ctl",
                    "apply": "return JSON.stringify({ speed: message });"
                },
                "getRotationDirection": {
                    "topic": "fan/bedroom/fan",
                    "apply": "return JSON.parse(message).mode == 'auto' ? 0 : 1;"
                },
                "setRotationDirection": {
                    "topic": "fan/bedroom/ctl",
                    "apply": "return JSON.stringify({ mode: message ? 'manual' : 'auto' });"
                }
            }
        },
 
```