### PR TITLE
Add Elgato History support for AirQuality

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Air quality state can be `UNKNOWN`, `EXCELLENT`, `GOOD`, `FAIR`, `INFERIOR` or `
     {
         "getAirQuality":         "<topic used to report air quality",
         "getCarbonDioxideLevel": "<topic used to report carbon dioxide level (optional)>",
+        "getAirQualityPPM":      "<topic used to report air quality voc in ppm (optional)",
         "getStatusActive":       "<topic used to provide 'active' status (optional)>",
         "getStatusFault":        "<topic used to provide 'fault' status (optional)>",
         "getStatusTampered":     "<topic used to provide 'tampered' status (optional)>",

--- a/test/config.json
+++ b/test/config.json
@@ -462,8 +462,10 @@
       "url": "http://192.168.10.35:1883",
       "logMqtt": "true",
       "topics": {
-        "getAirQuality": "test/airquality/get"
-      }
+        "getAirQuality": "test/airquality/get",
+        "getAirQualityPPM": "test/airqualityppm/get"
+      },
+      "history": true
     }
   ]
 }


### PR DESCRIPTION
This PR builds on top of @tobekas History PR and adds reporting Air Quality history to the project:
Subscribe to a topic that reports back the
airquality in ppm and commit that data to
fakegato-history, in order for a graph to be
displayed in Eve Room.

I hope this PR is not too controversial, because Air Quality in itself requires a custom characteristic (that's specific to Eve) to be added to homebridge-mqttthing. We kind of already do this with fakegato-history, but not in the main mqtt code.
I hope this is not a problem though.

Either way, thanks for the work being put into this so far. Mqttthing is great! :)

![IMG_120320A742E5-1](https://user-images.githubusercontent.com/5174440/55282876-c7221e80-534d-11e9-8596-718004893dc7.jpeg)
