### PR TITLE
History Service Part 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,9 +169,11 @@ Alternatively, you can specify `history` as an object with some properties:
 
 `size` - maximum size of stored data points (optional), default: 4032
 
-`interval` - set history interval [minutes] for averaging/repeating. 0 will disable this timer (optional), default: 10
+`autoTimer` - enable/disable averaging (and repeating) 10min timer (optional), default: true
 
-`autoRepeat` - set repetition of last value if no data was received in last interval (optional), default: true
+`autoRepeat` - enable/disable repetition of last value if no data was received in last 10min interval (optional), default: true
+
+`mergeInterval` - set merge interval [minutes] for events, which are very close in time (optional, for motion sensor only, not in combination with autoTimer/autoRepeat), default: 0
 
 Avoid the use of "/" in characteristics of the Information Service (e.g. serial number, manufacturer, etc.), since this may cause data to not appear in the history. Note that if your Eve.app is controlling more than one accessory for each type, the serial number should be unique, otherwise Eve.app will merge the histories.
 
@@ -199,6 +201,7 @@ Avoid the use of "/" in characteristics of the Information Service (e.g. serial 
    * [StatelessProgrammableSwitch](#statelessprogrammableswitch)
    * [Switch](#switch)
    * [Temperature Sensor](#temperature-sensor)
+   * [Temperature-Humidity Sensor](#temperature-humidity-sensor)
    * [Window](#window)
    * [Window Covering (Blinds)](#window-covering)
    
@@ -817,6 +820,38 @@ Current temperature must be in the range 0 to 100 degrees Celsius to a maximum o
     "topics":
     {
         "getCurrentTemperature":        "<topic used to provide 'current temperature'>",
+        "getStatusActive":              "<topic used to provide 'active' status (optional)>",
+        "getStatusFault":               "<topic used to provide 'fault' status (optional)>",
+        "getStatusTampered":            "<topic used to provide 'tampered' status (optional)>",
+        "getStatusLowBattery":          "<topic used to provide 'low battery' status (optional)>"
+    },
+    "history": "<true to enable History service for Eve App (optional)>"
+}
+```
+
+
+## Temperature-Humidity Sensor
+
+Current temperature must be in the range 0 to 100 degrees Celsius to a maximum of 1dp.
+Current relative humidity must be in the range 0 to 100 percent with no decimal places.
+
+```javascript
+{
+    "accessory": "mqttthing",
+    "type": "tempHumSensor",
+    "name": "<name of sensor>",
+    "serviceNames": {
+        "temperature": "<name for temperature service>",
+        "humidity": "<name for humidity service>"
+    },
+    "url": "<url of MQTT server (optional)>",
+    "username": "<username for MQTT (optional)>",
+    "password": "<password for MQTT (optional)>",
+    "caption": "<label (optional)>",
+    "topics":
+    {
+        "getCurrentTemperature":        "<topic used to provide 'current temperature'>",
+        "getCurrentRelativeHumidity":   "<topic used to provide 'current relative humidity'>",
         "getStatusActive":              "<topic used to provide 'active' status (optional)>",
         "getStatusFault":               "<topic used to provide 'fault' status (optional)>",
         "getStatusTampered":            "<topic used to provide 'tampered' status (optional)>",

--- a/index.js
+++ b/index.js
@@ -867,7 +867,6 @@ function makeThing(log, config) {
                     time: Math.floor(Date.now() / 1000),  // seconds (UTC)
                     status: (value ? 1 : 0)  // fakegato-history logProperty 'status' for motion sensor
                 };
-                log(value);
                 let mergeInterval = config.history.mergeInterval*60000 || 0;
 
                 if (logEntry.status) {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   "homepage": "https://github.com/arachnetech/homebridge-mqttthing#readme",
   "dependencies": {
     "mqtt": "^2.9.0",
-    "fakegato-history": "0.5.3"
+    "fakegato-history": "0.5.3",
+    "homebridge-lib": "~4.0.10"
   }
 }

--- a/test/config.json
+++ b/test/config.json
@@ -219,7 +219,6 @@
       },
       "history": {
         "size": 1000,
-        "interval": 5,
         "autoRepeat": false
       }
     },
@@ -231,7 +230,8 @@
       "topics": {
         "getContactSensorState": "test/contact/state"
       },
-      "integerValue": true
+      "integerValue": true,
+      "history": true
     },
     {
       "accessory": "mqttthing",


### PR DESCRIPTION
As promised, here is my second PR with some improvements.
Hope you like it and hopefully there are no new bugs in it.

----
additions/fixes/cleanups for HistoryService:
- use homebridge-lib from @ebaauw for custom Eve services/characteristics
- add history support for contact sensor (+ TimesOpened counter) !!!
- seperate HistoryCallback for each type
- remove config.history.interval (not possible with various accessories)
- turnOffAfterms for motion sensor working in combination with history
- auto merge motion events, which are very close in time
- add LastActivation characteristic

- add temperature/humidity combi sensor
- add custom service names for multi-service accessories