### PR TITLE
History Service Part 3 - Power Consumption for Outlets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/*
 npm-debug.log
 test/*_persist.json
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -645,6 +645,9 @@ and False (or 0) maps to `OCCUPANCY_NOT_DETECTED` (not triggered). To use differ
 
 An outlet can be configured as a light or as a fan in the Home app.
 
+If `history` is enabled and no `getTotalConsumption` topic is defined, this plugin will count the total consumption (kWh) by itself and offers the possibility to reset the counter from the Eve app.
+The interval of `getWatts` data updates should be less then 10min and at best periodic, in order to avoid averaging errors for the history entries.
+
 ```javascript
 {
     "accessory": "mqttthing",
@@ -656,14 +659,19 @@ An outlet can be configured as a light or as a fan in the Home app.
     "caption": "<label (optional)>",
     "topics":
     {
-        "getOn":            "<topic to get the status>",
-        "setOn":            "<topic to set the status>",
-        "getInUse":         "<topic used to provide 'outlet is in use' feedback>"
+        "getOn":                "<topic to get the status>",
+        "setOn":                "<topic to set the status>",
+        "getInUse":             "<topic used to provide 'outlet is in use' feedback>",
+        "getWatts":             "<topic used to provide 'current consumption' [Watts] (optional, Eve-App-only)>",
+        "getVolts":             "<topic used to provide 'voltage' [Volts] (optional, Eve-App-only)>",
+        "getAmperes":           "<topic used to provide 'electricCurrent' [Amperes] (optional, Eve-App-only)>",
+        "getTotalConsumption":  "<topic used to provide 'totalConsumption' [kWh] (optional, Eve-App-only)>"
     },
     "integerValue": "true to use 1|0 instead of true|false default onValue and offValue",
     "onValue": "<value representing on (optional)>",
     "offValue": "<value representing off (optional)>",
-    "turnOffAfterms": <milliseconds after which to turn off automatically (optional)>
+    "turnOffAfterms": "<milliseconds after which to turn off automatically (optional)>",
+    "history": "<true to enable History service for Eve App (optional)>"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ Carbon dioxide detected state can be `NORMAL` or `ABNORMAL`. To use different va
 Contact sensor state is exposed as a Boolean. True (or 1 with integer values) maps to `CONTACT_NOT_DETECTED` (sensor triggered)
 and False (or 0) maps to `CONTACT_DETECTED` (not triggered). To use different MQTT values, configure `onValue` and `offValue`.
 
+If `history` is enabled, this plugin will count the number of openings and offers the possibility to reset the counter from the Eve app.
+
 ```javascript
 {
     "accessory": "mqttthing",
@@ -282,7 +284,8 @@ and False (or 0) maps to `CONTACT_DETECTED` (not triggered). To use different MQ
     },
     "integerValue": "true to use 1|0 instead of true|false default onValue and offValue",
     "onValue": "<value representing on (optional)>",
-    "offValue": "<value representing off (optional)>"
+    "offValue": "<value representing off (optional)>",
+    "history": "<true to enable History service for Eve App (optional)>"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
   "dependencies": {
     "mqtt": "^2.9.0",
     "fakegato-history": "0.5.3",
-    "homebridge-lib": "~4.0.10"
+    "homebridge-lib": "~4.0.11"
   }
 }

--- a/test/config.json
+++ b/test/config.json
@@ -151,9 +151,13 @@
       "topics": {
         "getOn": "test/outlet/getOn",
         "setOn": "test/outlet/setOn",
-        "getInUse": "test/outlet/getInUse"
+        "getInUse": "test/outlet/getInUse",
+        "getWatts": "test/outlet/getWatts",
+        "getVolts": "test/outlet/getVolts",
+        "getAmperes": "test/outlet/getAmperes"
       },
-      "integerValue": true
+      "integerValue": true,
+      "history": true
     },
     {
       "accessory": "mqttthing",

--- a/test/config.json
+++ b/test/config.json
@@ -173,7 +173,9 @@
       "chargingStateValues": [ "NotCharging", "Charging", "NotChargeable" ],
       "logMqtt": true,
       "turnOffAfterms": 3000,
-      "history": true
+      "history": {
+        "mergeInterval": 5
+      }
     },
     {
       "accessory": "mqttthing",


### PR DESCRIPTION
Hi guys,
last but not least, I am happy to offer you energy consumption history service (for outlets) as well.
With this update, you can add "Watts", "Volts", "Amperes" (and "TotalConsumption") characteristics, which are visible in the Eve App. If no MQTT topic for "TotalConsumption" is available, this plugin will count the total consumption (kWh) by itself and offers the possibility to reset the counter from the Eve app.

In addition, a few corrections/additions regarding Eve characteristics are included:
- get initial "lastActivation" time after homebridge restart from history data (for motion and door sensor)
- avoid homebridge warnings on console for custom Eve characteristics
- use "homebridge-lib" 4.0.11 for definition of Eve.Characteristic.AirParticulateDensity (AirQualityPPM)

addSensorOptionalCharacteristics via function to allow these characteristics to be added to multiple services (e.g. for tempHumSensor).

I hope I could enrich mqttthing with these extensions... This would be my last contribution for now.
Best regards, TobeKas