### PR TITLE
Add quotes in config json example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ The following settings apply to all device types:
     "url": "http://192.168.1.235:1883",
     "username": "MQTT_username",
     "password": "MQTT_password",
-    "mqttOptions": { keepalive: 30 },
-    "mqttPubOptions": { retain: true },
+    "mqttOptions": { "keepalive": 30 },
+    "mqttPubOptions": { "retain": true },
     "logMqtt": true,
     "topics": {
         "getName": 	        "my/get/name/topic",


### PR DESCRIPTION
The readme contains a non standard json config example that may confuse some new users. 