### PR TITLE
Fix typo in config.schema.json

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1240,7 +1240,7 @@
             },
             "offlineValue": {
                 "type": "string",
-                "title": "Online Value",
+                "title": "Offline Value",
                 "description": "Value representing that an accessory is offline (as received through 'getOnline') if different to 'offValue'",
                 "default": "",
                 "examples": [


### PR DESCRIPTION
Fixed typo in the title of the 'offlineValue' property