### PR TITLE
Changed protocol for MQTT server from http:// to mqtt://

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -256,8 +256,8 @@
             "url": {
                 "type": "string",
                 "title": "URL",
-                "description": "URL of MQTT server (optional), default: http://localhost:1883",
-                "placeholder": "http://localhost:1883"
+                "description": "URL of MQTT server (optional), default: mqtt://localhost:1883",
+                "placeholder": "mqtt://localhost:1883"
             },
             "username": {
                 "type": "string",

--- a/docs/Codecs.md
+++ b/docs/Codecs.md
@@ -394,7 +394,7 @@ For example, the following accessory configuration:
     "accessory": "mqttthing",
     "type": "lightbulb",
     "name": "Test RGB Light",
-    "url": "http://192.168.10.35:1883",
+    "url": "mqtt://192.168.10.35:1883",
     "topics": {
         "getRGB": "test/rgblight/get",
         "setRGB": "test/rgblight/set",

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -39,7 +39,7 @@ The following settings apply to all device types:
     "accessory": "mqttthing",
     "type": "lightbulb",
     "name": "My lightbulb",
-    "url": "http://192.168.1.235:1883",
+    "url": "mqtt://192.168.1.235:1883",
     "username": "MQTT_username",
     "password": "MQTT_password",
     "mqttOptions": { "keepalive": 30 },
@@ -77,7 +77,7 @@ The following settings apply to all device types:
 
 ### MQTT Settings
 
-`url` - URL of MQTT server if not localhost port 1883 (optional)
+`url` - URL of MQTT server if not localhost port 1883 (optional). The URL can be one of the following protocols: 'mqtt', 'mqtts', 'tcp', 'tls', 'ws', 'wss'. The url is passed to [mqtt.connect()](https://github.com/mqttjs/MQTT.js#connect).
 
 `username` - Username for MQTT server (optional)
 

--- a/test/config.json
+++ b/test/config.json
@@ -20,7 +20,7 @@
         {
             "type": "lightbulb-Colour",
             "name": "Test lightbulb",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "mqttPubOptions": {
                 "retain": true
             },
@@ -68,7 +68,7 @@
         {
             "type": "lightbulb-HSV",
             "name": "Test HSV Light",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "logMqtt": true,
             "topics": {
                 "setHSV": "test/hsvlight/setHSV",
@@ -85,7 +85,7 @@
             "accessory": "mqttthing",
             "type": "lightbulb-HSV",
             "name": "Test espurna Light",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "topics": {
                 "getHSV": "test/hsvlight2/hsv",
                 "setHSV": "test/hsvlight2/hsv/set",
@@ -103,7 +103,7 @@
             "accessory": "mqttthing",
             "type": "lightbulb",
             "name": "Test RGB Light",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "topics": {
                 "getRGB": "test/rgblight/get",
                 "setRGB": "test/rgblight/set",
@@ -128,7 +128,7 @@
             "accessory": "mqttthing",
             "type": "lightbulb-RGBW",
             "name": "Test RGBW Light",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "topics": {
                 "getRGBW": "test/rgbwlight/rgb",
                 "setRGBW": "test/rgbwlight/rgb/set"
@@ -141,7 +141,7 @@
             "accessory": "mqttthing",
             "type": "lightbulb-RGB",
             "name": "Test RGBW Light 2",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "topics": {
                 "getRGB": "test/rgbwlight2",
                 "setRGB": "test/rgbwlight2/set",
@@ -166,7 +166,7 @@
             "accessory": "mqttthing",
             "type": "lightbulb-RGBWW",
             "name": "Test RGBWW Light",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "topics": {
                 "getRGBWW": "test/rgbwwlight/rgb",
                 "setRGBWW": "test/rgbwwlight/rgb/set"
@@ -177,7 +177,7 @@
             "accessory": "mqttthing",
             "type": "lightbulb-White",
             "name": "Test White Light",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "topics": {
                 "getWhite": "test/whitelight/white",
                 "setWhite": "test/whitelight/white/set"
@@ -188,7 +188,7 @@
             "accessory": "mqttthing",
             "type": "lightbulb-ColTemp",
             "name": "Test ColorTemperature Light",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "topics": {
                 "getOn": "test/coltemp/getOn",
                 "setOn": "test/coltemp/setOn",
@@ -204,7 +204,7 @@
             "accessory": "mqttthing",
             "type": "lightbulb-Dimmable",
             "name": "Test Dimmable Light",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "topics": {
                 "getOn": "test/dimmable/setOn",
                 "setOn": "test/dimmable/setOn",
@@ -221,7 +221,7 @@
             "accessory": "mqttthing",
             "type": "lightbulb-OnOff",
             "name": "Alternative Light Mode",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "topics": {
                 "getOn": "test/dimmable/setOn",
                 "setOn": "test/dimmable/setOn"
@@ -235,7 +235,7 @@
             "accessory": "mqttthing",
             "type": "switch",
             "name": "Test switch",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "topics": {
                 "getOn": "test/switch/getOn",
                 "setOn": "test/switch/setOn"
@@ -247,7 +247,7 @@
             "accessory": "mqttthing",
             "type": "switch",
             "name": "Test switch 2",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "topics": {
                 "getOn": "test/switch2/getOn",
                 "setOn": "test/switch2/setOn"
@@ -259,7 +259,7 @@
             "accessory": "mqttthing",
             "type": "outlet",
             "name": "Test outlet",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "mqttPubOptions": {
                 "retain": true
             },
@@ -295,13 +295,13 @@
                 "setOn": "shellies/shelly1-2C6BF0/relay/0/command"
             },
             "type": "switch",
-            "url": "http://192.168.10.35:1883"
+            "url": "mqtt://192.168.10.35:1883"
         },
         {
             "accessory": "mqttthing",
             "type": "motionSensor",
             "name": "Test motion sensor",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "topics": {
                 "getMotionDetected": "test/motion/detected",
                 "getStatusActive": "test/motion/active",
@@ -327,7 +327,7 @@
             "accessory": "mqttthing",
             "type": "occupancySensor",
             "name": "Test occupancy sensor",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "topics": {
                 "getOccupancyDetected": "test/occupancy/detected",
                 "getStatusActive": "test/occupancy/active",
@@ -341,7 +341,7 @@
             "accessory": "mqttthing",
             "type": "lightSensor",
             "name": "Test light sensor",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "logMqtt": true,
             "topics": {
                 "getCurrentAmbientLightLevel": "test/light/level"
@@ -351,7 +351,7 @@
             "accessory": "mqttthing",
             "type": "temperatureSensor",
             "name": "Test temperature sensor",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "topics": {
                 "getCurrentTemperature": "test/temperature"
             },
@@ -363,7 +363,7 @@
             "accessory": "mqttthing",
             "type": "humiditySensor",
             "name": "Test humidity sensor",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "topics": {
                 "getCurrentRelativeHumidity": "test/humidity"
             },
@@ -377,7 +377,7 @@
             "accessory": "mqttthing",
             "type": "airPressureSensor",
             "name": "Test air pressure sensor",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "topics": {
                 "getAirPressure": "test/airpressure"
             },
@@ -412,7 +412,7 @@
             "accessory": "mqttthing",
             "type": "contactSensor",
             "name": "Test contact sensor",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "topics": {
                 "getContactSensorState": "test/contact/state"
             },
@@ -423,7 +423,7 @@
             "accessory": "mqttthing",
             "type": "doorbell",
             "name": "Test doorbell",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "logMqtt": true,
             "topics": {
                 "getSwitch": "test/doorbell/ring",
@@ -442,7 +442,7 @@
             "accessory": "mqttthing",
             "type": "securitySystem",
             "name": "Test Security System",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "logMqtt": true,
             "topics": {
                 "setTargetState": "test/security/target",
@@ -472,7 +472,7 @@
             "accessory": "mqttthing",
             "type": "smokeSensor",
             "name": "Test smoke sensor",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "logMqtt": true,
             "topics": {
                 "getSmokeDetected": "test/smoke/detected"
@@ -483,7 +483,7 @@
             "accessory": "mqttthing",
             "type": "leakSensor",
             "name": "Test leak sensor",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "logMqtt": true,
             "topics": {
                 "getLeakDetected": "test/leak/detected"
@@ -495,7 +495,7 @@
             "accessory": "mqttthing",
             "type": "statelessProgrammableSwitch",
             "name": "Test Stateless Programmable Switch",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "logMqtt": true,
             "topics": {
                 "getSwitch": "test/spswitch/state"
@@ -509,7 +509,7 @@
             "accessory": "mqttthing",
             "type": "statelessProgrammableSwitch",
             "name": "Multi-switch",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "logMqtt": true,
             "topics": {
                 "getSwitch": [
@@ -523,7 +523,7 @@
             "accessory": "mqttthing",
             "type": "garageDoorOpener",
             "name": "Test Garage Door",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "logMqtt": true,
             "topics": {
                 "setTargetDoorState": "test/garage/target",
@@ -552,7 +552,7 @@
             "accessory": "mqttthing",
             "type": "garageDoorOpener",
             "name": "Simple Garage Door",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "logMqtt": true,
             "topics": {
                 "setTargetDoorState": "test/garage2/target",
@@ -568,7 +568,7 @@
             "accessory": "mqttthing",
             "type": "lockMechanism",
             "name": "Test Lock",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "logMqtt": true,
             "topics": {
                 "setLockTargetState": "test/lock/target",
@@ -586,7 +586,7 @@
             "accessory": "mqttthing",
             "type": "fan",
             "name": "Test Fan",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "logMqtt": true,
             "topics": {
                 "getOn": "test/fan/getOn",
@@ -602,7 +602,7 @@
             "accessory": "mqttthing",
             "type": "lightbulb",
             "name": "OnOffTest",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "logMqtt": "true",
             "topics": {
                 "getOn": "test/onoff/getOn",
@@ -615,7 +615,7 @@
             "accessory": "mqttthing",
             "type": "switch",
             "name": "Morning Scene",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "logMqtt": "true",
             "topics": {
                 "getOn": "test/scene/name",
@@ -627,7 +627,7 @@
             "accessory": "mqttthing",
             "type": "switch",
             "name": "Afternoon Scene",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "logMqtt": "true",
             "topics": {
                 "getOn": "test/scene/name",
@@ -639,7 +639,7 @@
             "accessory": "mqttthing",
             "type": "switch",
             "name": "Evening Scene",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "logMqtt": "true",
             "topics": {
                 "getOn": "test/scene/name",
@@ -651,7 +651,7 @@
             "accessory": "mqttthing",
             "type": "speaker",
             "name": "Speaker",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "logMqtt": "true",
             "topics": {
                 "getMute": "test/speaker/getMute",
@@ -664,7 +664,7 @@
             "accessory": "mqttthing",
             "type": "microphone",
             "name": "Microphone",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "logMqtt": "true",
             "topics": {
                 "getMute": "test/microphone/getMute",
@@ -677,7 +677,7 @@
             "accessory": "mqttthing",
             "type": "windowCovering",
             "name": "Blind",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "logMqtt": "true",
             "topics": {
                 "getCurrentPosition": "test/blind/getCurrentPosition",
@@ -691,7 +691,7 @@
             "accessory": "mqttthing",
             "type": "window",
             "name": "Window",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "logMqtt": "true",
             "topics": {
                 "getCurrentPosition": "test/window/getCurrentPosition",
@@ -703,7 +703,7 @@
             "accessory": "mqttthing",
             "type": "carbonDioxideSensor",
             "name": "CO2",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "logMqtt": "true",
             "topics": {
                 "getCarbonDioxideDetected": "test/co2/get"
@@ -713,7 +713,7 @@
             "accessory": "mqttthing",
             "type": "airQualitySensor",
             "name": "AirQuality",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "logMqtt": "true",
             "topics": {
                 "getAirQuality": "test/airquality/get",
@@ -736,7 +736,7 @@
             "type": "valve",
             "valveType": "sprinkler",
             "name": "Sprinkler",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "topics": {
                 "getActive": "test/sprinkler/getActive",
                 "setActive": "test/sprinkler/setActive",
@@ -753,7 +753,7 @@
             "accessory": "mqttthing",
             "type": "thermostat",
             "name": "Thermostat",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "logMqtt": "true",
             "topics": {
                 "getCurrentHeatingCoolingState": "test/thermostat/getCurrentState",
@@ -777,7 +777,7 @@
             "accessory": "mqttthing",
             "type": "heaterCooler",
             "name": "HeaterCooler",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "logMqtt": true,
             "topics": {
                 "setActive": "test/heatcool/setActive",
@@ -799,7 +799,7 @@
             "accessory": "mqttthing",
             "type": "television",
             "name": "Television",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "topics": {
                 "setActive": "test/television/setActive",
                 "getActive": "test/television/getActive",
@@ -840,7 +840,7 @@
             "model": "IN-9008 FullHD",
             "serialNumber": "1234567890",
             "firmwareRevision": "0.1",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "username": "USERNAME",
             "password": "PASSWORD",
             "caption": "Audio",
@@ -870,7 +870,7 @@
             "accessory": "mqttthing",
             "type": "switch",
             "name": "Hallway Lights",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "manufacturer": "Sonoff",
             "model": "Touch",
             "serialNumber": "sonoff1",
@@ -896,7 +896,7 @@
             "accessory": "mqttthing",
             "type": "statelessProgrammableSwitch",
             "name": "4 Button Remote",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "caption": "4 Button Remote",
             "topics": {
                 "getSwitch": [
@@ -930,7 +930,7 @@
             "accessory": "mqttthing",
             "type": "irrigationSystem",
             "name": "Irrigation",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "topics": {
                 "getActive": "test/irrigation/getActive",
                 "setActive": "test/irrigation/setActive"
@@ -968,7 +968,7 @@
             "accessory": "mqttthing",
             "type": "airPurifier",
             "name": "Air Purifier",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "topics": {
                 "getActive": "test/airpurifier/getActive",
                 "setActive": "test/airpurifier/setActive",

--- a/test2/config.json
+++ b/test2/config.json
@@ -30,7 +30,7 @@
             "type": "valve",
             "valveType": "sprinkler",
             "name": "Sprinkler",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "topics": {
                 "getActive": "test/sprinkler/getActive",
                 "setActive": "test/sprinkler/setActive",
@@ -121,7 +121,7 @@
             "accessory": "mqttthing",
             "type": "lightbulb",
             "name": "Test RGB Light",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "topics": {
                 "getRGB": "test/rgblight/get",
                 "setRGB": "test/rgblight/set",
@@ -312,7 +312,7 @@
             "accessory": "mqttthing",
             "type": "lightbulb-RGBWW",
             "name": "Test RGBWW Light",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "topics": {
                 "getRGBWW": "test/rgbwwlight/rgb",
                 "setRGBWW": "test/rgbwwlight/rgb/set"
@@ -324,7 +324,7 @@
             "accessory": "mqttthing",
             "type": "fan",
             "name": "Test Fan",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "logMqtt": true,
             "topics": {
                 "getRotationDirection": "test/fan/getRotationDirection",
@@ -341,7 +341,7 @@
             "accessory": "mqttthing",
             "type": "battery",
             "name": "Test Battery",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "logMqtt": true,
             "topics": {
                 "getBatteryLevel": "battery/level",
@@ -351,7 +351,7 @@
         {
             "type": "lightbulb-RGB",
             "name": "Color Light",
-            "url": "http://192.168.10.35:1883",
+            "url": "mqtt://192.168.10.35:1883",
             "topics": {
                 "getOnline": "getOnline",
                 "getOn": "getState",


### PR DESCRIPTION
Changed protocol for MQTT server from `http://` to `mqtt://` in the config url field:

- [x] Schema
- [x] Documentation
- [x] Example configuration JSON

Fixes #377.
