### PR TITLE
Avoid setLockTargetState value type issue since homebridge 1.3.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1112,6 +1112,11 @@ function makeThing( log, accessoryConfig ) {
                 if( setTopic ) {
                     charac.on( 'set', function( value, callback, context ) {
                         if( context !== c_mySetContext ) {
+                            
+                            if (typeof value === "boolean") {
+                                value = value? 1: 0;
+                            }
+                            
                             state[ property ] = value;
                             let mqttVal = values[ value ];
                             if( mqttVal !== undefined ) {


### PR DESCRIPTION
To avoid value type [issue](https://github.com/homebridge/homebridge/issues/2855#issue-821972063)  since homebridge 1.3.0.