### PR TITLE
#438: Cannot convert null to string

### DIFF
--- a/index.js
+++ b/index.js
@@ -1279,7 +1279,7 @@ function makeThing( log, accessoryConfig, api ) {
                 // MQTT set (Homekit get)
                 if( getTopic ) {
                     mqttSubscribe( getTopic, property, function( topic, message ) {
-                        let data = message.toString();
+                        let data = message?.toString() ?? '';
                         let newState = mqttToHomekit[ data ];
                         if( newState !== undefined && ( eventOnly || state[ property ] != newState ) ) {
                             if( config.logMqtt ) {


### PR DESCRIPTION
This fixes error when trying to convert message to string with `null` value.

Original issue link: https://github.com/arachnetech/homebridge-mqttthing/issues/438