### PR TITLE
Set mqtt retain option to false in docs

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -44,7 +44,7 @@ The following settings apply to all device types:
     "username": "MQTT_username",
     "password": "MQTT_password",
     "mqttOptions": { "keepalive": 30 },
-    "mqttPubOptions": { "retain": true },
+    "mqttPubOptions": { "retain": false },
     "logMqtt": true,
     "topics": {
         "getName": 	        "my/get/name/topic",


### PR DESCRIPTION
I'd suggest that the default value in the docs to retain mqtt messages is shown as false.

Having it set to true may lead (as it did for me) to "ghost switching" issues with light bulb as well as outlet devices.

A really nice explanation of why this happens is explained in this [blog post](http://www.thesmarthomehookup.com/end-random-ghost-switching-for-good-by-fixing-your-retain-settings-in-tasmota-and-home-assistant/).

I do get, that this is only supposed to show the possibilities, but uninitiated lazy people like me tend to copy the config and leave it as is.