### PR TITLE
Alternate triggered status

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1019,6 +1019,13 @@
                             "functionBody": "return ['airPressureSensor','airQualitySensor','carbonDioxideSensor','carbonMonoxideSensor','contactSensor','humiditySensor','leakSensor','lightSensor','motionSensor','occupancySensor','securitySystem','smokeSensor','temperatureSensor','valve','weatherStation'].includes(model.type);"
                         }
                     },
+                    "getAltStatusTriggered": {
+                        "type": "string",
+                        "description": "Topic used to notify mqttthing that an alarm Triggered has been achieved. HomeKit will expect current state to end up matching target state.",
+                        "condition": {
+                            "functionBody": "return ['securitySystem'].includes(model.type);"
+                        }
+                    },
                     "getSulphurDioxideDensity": {
                         "type": "string",
                         "description": "Topic used to notify mqttthing of 'sulphur dioxide density'",
@@ -1811,6 +1818,7 @@
                 "topics.getStatusLowBattery",
                 "topics.getChargingState",
                 "topics.getStatusTampered",
+                "topics.getAltStatusTriggered",
                 "topics.getOnline",
                 "topics.getFilterChangeIndication",
                 "topics.getFilterLifeLevel",

--- a/docs/Accessories.md
+++ b/docs/Accessories.md
@@ -790,6 +790,7 @@ Configure `restrictTargetState` to an array of integers to restrict the target s
         "getCurrentState":   "<topic used to get 'current state'>",
         "getStatusFault":    "<topic used to provide 'fault' status (optional)>",
         "getStatusTampered": "<topic used to provide 'tampered' status (optional)>"
+        "getAltStatusTriggered": "<topic used to provide an alternative 'triggered' boolean status (optional)>"
     },
     "targetStateValues": [ "StayArm", "AwayArm", "NightArm", "Disarmed" ],
     "currentStateValues": [ "StayArm", "AwayArm", "NightArm", "Disarmed", "Triggered" ],

--- a/index.js
+++ b/index.js
@@ -1540,7 +1540,7 @@ function makeThing( log, accessoryConfig, api ) {
             
             // Characteristic.AltStatusTriggered : This helps to use multisensor securitySystem (one for the ARMED/DISARMED and on another for the triggered sensor)
             function characteristic_AltStatusTriggered ( service ) {
-                multiCharacteristic( service, 'altStatusTriggered', Characteristic.AltStatusTriggered, null, config.topics.getAltStatusTriggered );
+                booleanCharacteristic( service, 'altStatusTriggered', Characteristic.AltStatusTriggered, null, config.topics.getAltStatusTriggered );
             }
 
             // Characteristic.StatusLowBattery

--- a/index.js
+++ b/index.js
@@ -1540,7 +1540,7 @@ function makeThing( log, accessoryConfig, api ) {
             
             // Characteristic.AltStatusTriggered : This helps to use multisensor securitySystem (one for the ARMED/DISARMED and on another for the triggered sensor)
             function characteristic_AltStatusTriggered ( service ) {
-                booleanCharacteristic( service, 'altStatusTriggered', Characteristic.AltStatusTriggered, null, config.topics.getAltStatusTriggered );
+                multiCharacteristic( service, 'altStatusTriggered', Characteristic.AltStatusTriggered, null, config.topics.getAltStatusTriggered );
             }
 
             // Characteristic.StatusLowBattery

--- a/index.js
+++ b/index.js
@@ -1540,6 +1540,7 @@ function makeThing( log, accessoryConfig, api ) {
             
             // Characteristic.AltStatusTriggered : This helps to use multisensor securitySystem (one for the ARMED/DISARMED and on another for the triggered sensor)
             function characteristic_AltStatusTriggered ( service ) {
+                service.addOptionalCharacteristic( Characteristic.AltStatusTriggered );
                 booleanCharacteristic( service, 'altStatusTriggered', Characteristic.AltStatusTriggered, null, config.topics.getAltStatusTriggered );
             }
 

--- a/index.js
+++ b/index.js
@@ -2659,9 +2659,6 @@ function makeThing( log, accessoryConfig, api ) {
                 if( config.topics.getStatusTampered ) {
                     characteristic_StatusTampered( service );
                 }
-                if( config.topics.getAltStatusTriggered ) {
-                    characteristic_AltStatusTriggered( service );
-                }
                 if( config.topics.getStatusLowBattery ) {
                     characteristic_StatusLowBattery( service );
                 }

--- a/index.js
+++ b/index.js
@@ -1537,6 +1537,11 @@ function makeThing( log, accessoryConfig, api ) {
             function characteristic_StatusTampered( service ) {
                 booleanCharacteristic( service, 'statusTampered', Characteristic.StatusTampered, null, config.topics.getStatusTampered );
             }
+            
+            // Characteristic.AltStatusTriggered : This helps to use multisensor securitySystem (one for the ARMED/DISARMED and on another for the triggered sensor)
+            function characteristic_AltStatusTriggered ( service ) {
+                booleanCharacteristic( service, 'altStatusTriggered', Characteristic.AltStatusTriggered, null, config.topics.getAltStatusTriggered );
+            }
 
             // Characteristic.StatusLowBattery
             function characteristic_StatusLowBattery( service ) {
@@ -2654,6 +2659,10 @@ function makeThing( log, accessoryConfig, api ) {
                 if( config.topics.getStatusTampered ) {
                     characteristic_StatusTampered( service );
                 }
+                if( config.topics.getAltStatusTriggered ) {
+                    characteristic_AltStatusTriggered( service );
+                }
+                
                 if( config.topics.getStatusLowBattery ) {
                     characteristic_StatusLowBattery( service );
                 }
@@ -2953,6 +2962,9 @@ function makeThing( log, accessoryConfig, api ) {
                 }
                 if( config.topics.getStatusTampered ) {
                     characteristic_StatusTampered( service );
+                }
+                if( config.topics.getAltStatusTriggered ) {
+                    characteristic_AltStatusTriggered( service );
                 }
                 // todo: SecuritySystemAlarmType
             } else if( configType == "smokeSensor" ) {

--- a/index.js
+++ b/index.js
@@ -2662,7 +2662,6 @@ function makeThing( log, accessoryConfig, api ) {
                 if( config.topics.getAltStatusTriggered ) {
                     characteristic_AltStatusTriggered( service );
                 }
-                
                 if( config.topics.getStatusLowBattery ) {
                     characteristic_StatusLowBattery( service );
                 }


### PR DESCRIPTION
I suggest to create an Alternate Triggered State to help detecting triggered state with alternate sensors.
This optional altStatusTriggered could then be use in a specific codec.

        if (info.property == "altStatusTriggered") {
            if (msg == 0 && current_state == "AA") {
            	trigger_state = true;
            	log("Triggered state detected , notifying !!!");
            	notify(config.currentState,4);
            } else { trigger_state = false;}
           
	return undefined;
	}