### PR TITLE
Pass extendedTopic object to decode/encode codec functions

### DIFF
--- a/docs/Codecs.md
+++ b/docs/Codecs.md
@@ -112,6 +112,7 @@ The `encode()` function is called to encode a message before publishing it to MQ
    * `info` is an object holding:
       * `info.topic` - the MQTT topic to be published
       * `info.property` - the property associated with the publishing operation
+      * `info.extendedTopic` - the whole object passed in the configuration (`null` if topic was a string)
    * `output` is a function which may be called to deliver the encoded value asynchronously
 
 The `encode()` function may either return the encoded message, or it may deliver it asynchronously by passing it as a parameter to the provided `output` function. It if does neither, no value will be published.
@@ -124,6 +125,7 @@ The `decode`() function is called to decode a message received from MQTT before 
    * `info` is an object holding:
       * `info.topic` - the MQTT topic received
       * `info.property` the property associated with the received message
+      * `info.extendedTopic` - the whole object passed in the configuration (`null` if topic was a string)
    * `output` is a function which may be called to deliver the decoded value asynchronously
 
 The `decode()` function may either return the decoded message, or it may deliver it asynchronously by passing it as a parameter to the provided `output` function. If it does neither, no notification will be passed on to MQTT-Thing.

--- a/libs/mqttlib.js
+++ b/libs/mqttlib.js
@@ -240,9 +240,10 @@ var mqttlib = new function() {
             }
         }
 
+        let extendedTopic = null
         // send through any apply function
         if (typeof topic != 'string') {
-            let extendedTopic = topic;
+            extendedTopic = topic;
             topic = extendedTopic.topic;
             if (extendedTopic.hasOwnProperty('apply')) {
                 let previous = handler;
@@ -272,7 +273,7 @@ var mqttlib = new function() {
                 return realHandler( topic, message );
             };
             handler = function( intopic, message ) {
-                let decoded = codecDecode( message, { topic, property }, output );
+                let decoded = codecDecode( message, { topic, property, extendedTopic }, output );
                 if( config.logMqtt ) {
                     log( 'codec decoded message to [' + decoded + ']' );
                 }
@@ -337,10 +338,11 @@ var mqttlib = new function() {
             return; // don't publish if message is null or topic is undefined
         }
 
+        let extendedTopic = null
         // first of all, pass message through any user-supplied apply() function
         if (typeof topic != 'string') {
             // encode data with user-supplied apply() function
-            var extendedTopic = topic;
+            extendedTopic = topic;
             topic = extendedTopic.topic;
             if (extendedTopic.hasOwnProperty('apply')) {
                 var applyFn = Function( "message", "state", extendedTopic['apply'] ); //eslint-disable-line
@@ -364,7 +366,7 @@ var mqttlib = new function() {
         let codecEncode = getCodecFunction( codec, property, 'encode' );
         if( codecEncode ) {
             // send through codec's encode function
-            let encoded = codecEncode( message, { topic, property }, publishImpl );
+            let encoded = codecEncode( message, { topic, property, extendedTopic }, publishImpl );
             if( encoded !== undefined ) {
                 publishImpl( encoded );
             }


### PR DESCRIPTION
When a codec is dealing with multiple services (`custom` accessory), there must be a way to discern those in the decode/encode function.

By passing the whole object `extendedTopic` (when defined as object instead of string), a developer could easily add an attribute identifying different services with the same chars (example: two switches).