### PR TITLE
Add characteristic_Active to thermostat

### DIFF
--- a/index.js
+++ b/index.js
@@ -3218,6 +3218,7 @@ function makeThing( log, accessoryConfig, api ) {
                 addSensorOptionalCharacteristics( service );
             } else if( configType == 'thermostat' ) {
                 service = new Service.Thermostat( name, subtype );
+                characteristic_Active( service );
                 characteristic_CurrentHeatingCoolingState( service );
                 characteristic_TargetHeatingCoolingState( service );
                 characteristic_CurrentTemperature( service );


### PR DESCRIPTION
Currently there's no way to set a thermostat as on/off if it uses another topic to perform that function. Adding the characteristic_Active( service ); to the thermostat configtype should fix this 