### PR TITLE
Add accessory information fields to config UI

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1679,6 +1679,26 @@
                 "items": {
                     "type": "string"
                 }
+            },
+            "manufacturer": {
+              "type": "string",
+              "title": "Manufacturer",
+              "description": "Defaults to mqttthing"
+            },
+            "model": {
+              "type": "string",
+              "title": "Model",
+              "description": "Defaults to accessory type"
+            },
+            "serialNumber": {
+              "type": "string",
+              "title": "Serial Number",
+              "description": "defaults to hostname and accessory name joined by a dash"
+            },
+            "firmwareRevision": {
+              "type": "string",
+              "title": "Firmware Revision",
+              "description": "defaults to mqttthing version"
             }
         }
     },
@@ -1943,6 +1963,17 @@
                 },
                 "topics.getName"
             ]
+        },
+        {
+          "type": "fieldset",
+          "expandable": "true",
+          "title": "Accessory Information",
+          "items": [
+            "manufacturer",
+            "model",
+            "serialNumber",
+            "firmwareRevision"
+          ]
         }
     ]
 }


### PR DESCRIPTION
I wanted to move my mqttthing devices across hosts without changing the serial numbers. I found that could be achieved by altering the config, and that thought it would be an improvement if you could change those fields directly in the UI. 

The fields I added to the UI are:

- manufacturer
- model
- serialNumber
- firmwareVersion
<img width="749" alt="Screenshot 2022-12-13 at 19 25 15" src="https://user-images.githubusercontent.com/1965587/207426875-23a0f6fa-0b7b-4c1e-9d14-50a7a5a41226.png">

I identified those from here:

https://github.com/arachnetech/homebridge-mqttthing/blob/cb399ac261063650a892757b526c2238310f65fe/index.js#L25-L32

Hope this helps!