### PR TITLE
Adding support for Carbon Monoxide Sensor(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The following Homekit accessory types are supported by MQTT-Thing:
    * [Air Purifier](docs/Accessories.md#air-purifier)
    * [Air Quality Sensor](docs/Accessories.md#air-quality-sensor)
    * [Carbon Dioxide Sensor](docs/Accessories.md#carbon-dioxide-sensor)
+   * [Carbon Monoxide Sensor](docs/Accessories.md#carbon-monoxide-sensor)
    * [Contact Sensor](docs/Accessories.md#contact-sensor)
    * [Door](docs/Accessories.md#door)
    * [Doorbell](docs/Accessories.md#doorbell)

--- a/docs/Accessories.md
+++ b/docs/Accessories.md
@@ -11,6 +11,7 @@ The following Homekit accessory types are supported by MQTT-Thing:
    * [Air Purifier](#air-purifier)
    * [Air Quality Sensor](#air-quality-sensor)
    * [Carbon Dioxide Sensor](#carbon-dioxide-sensor)
+   * [Carbon Monoxide Sensor](#carbon-monoxide-sensor)
    * [Contact Sensor](#contact-sensor)
    * [Dehumidifier](#dehumidifier)
    * [Door](#door)
@@ -187,6 +188,29 @@ Carbon dioxide detected state can be `NORMAL` or `ABNORMAL`. To use different va
         "getStatusLowBattery":          "<topic used to provide 'low battery' status (optional)>"
     },
     "carbonDioxideDetectedValues": [ "normal-value", "abnormal-value" ]
+}
+```
+
+## Carbon Monoxide Sensor
+
+Carbon Monoxide detected state can be `NORMAL` or `ABNORMAL`. To use different values, specify them in **carbonMonoxideDetectedValues** in that order.
+
+```javascript
+{
+    "accessory": "mqttthing",
+    "type": "carbonMonoxideSensor",
+    "name": "<name of device>",
+    "topics":
+    {
+        "getCarbonMonoxideDetected":     "<topic used to report carbon Monoxide detected",
+        "getCarbonMonoxideLevel":        "<topic used to report carbon Monoxide level (optional)>",
+        "getCarbonMonoxidePeakLevel":    "<topic used to report carbon Monoxide level (optional)>",
+        "getStatusActive":              "<topic used to provide 'active' status (optional)>",
+        "getStatusFault":               "<topic used to provide 'fault' status (optional)>",
+        "getStatusTampered":            "<topic used to provide 'tampered' status (optional)>",
+        "getStatusLowBattery":          "<topic used to provide 'low battery' status (optional)>"
+    },
+    "carbonMonoxideDetectedValues": [ "normal-value", "abnormal-value" ]
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -2166,10 +2166,23 @@ function makeThing( log, accessoryConfig, api ) {
                 floatCharacteristic( service, 'VOCDensity', Characteristic.VOCDensity, null, config.topics.getVOCDensity );
             }
 
-            // Characteristic.CarbonMonoxideDensity
-            function characteristic_CarbonMonoxideLevel( service ) {
-                floatCharacteristic( service, 'carbonMonoxideLevel', Characteristic.CarbonMonoxideLevel, null, config.topics.getCarbonMonoxideLevel );
+            // Characteristic.CarbonMonoxideLevel
+            function characteristic_CarbonMonoxideLevel(service) {
+                floatCharacteristic(service, 'carbonMonoxideLevel', Characteristic.CarbonMonoxideLevel, null, config.topics.getCarbonMonoxideLevel);
             }
+            // Characteristic.CarbonMonoxideDetected
+            function characteristic_CarbonMonoxideDetected(service) {
+                    let values = config.carbonMonoxideDetectedValues;
+                    if (!values) {
+                            values =['NORMAL', 'ABNORMAL'];
+                        }
+                    multiCharacteristic(service, 'carbonMonoxideDetected', Characteristic.CarbonMonoxideDetected, null, config.topics.getCarbonMonoxideDetected, values, Characteristic.CarbonMonoxideDetected.CO_LEVELS_NORMAL);
+                }
+
+            // Characteristic.CarbonMonoxidePeakLevel
+            function characteristic_CarbonMonoxidePeakLevel(service) {
+                    floatCharacteristic(service, 'carbonMonoxidePeakLevel', Characteristic.CarbonMonoxidePeakLevel, null, config.topics.getCarbonMonoxidePeakLevel, 0);
+                }
 
             // Eve.Characteristics.AirParticulateDensity (Eve-only)
             function characteristic_AirQualityPPM( service ) {
@@ -3258,6 +3271,16 @@ function makeThing( log, accessoryConfig, api ) {
                 }
                 if( config.topics.getCarbonDioxidePeakLevel ) {
                     characteristic_CarbonDioxidePeakLevel( service );
+                }
+            } else if ( configType == 'carbonMonoxideSensor' ) {
+                service = new Service.CarbonMonoxideSensor(name, subtype);
+                characteristic_CarbonMonoxideDetected(service);
+                addSensorOptionalCharacteristics(service);
+                if (config.topics.getcarbonMonoxideLevel) {
+                    characteristic_carbonMonoxideLevel(service);
+                }
+                if (config.topics.getcarbonMonoxidePeakLevel) {
+                    characteristic_carbonMonoxidePeakLevel(service);
                 }
             } else if( configType == 'valve' ) {
                 service = new Service.Valve( name, subtype );


### PR DESCRIPTION
Adding explicit support for Carbon Monoxide Sensor(s) such as the MOES Carbon Monoxide Alarm ZSS-HM-CO

[CC: [https://github.com/Koenkk/zigbee2mqtt/issues/19011](https://github.com/Koenkk/zigbee2mqtt/issues/19011)]