### PR TITLE
Remove underscore from accessory name

### DIFF
--- a/index.js
+++ b/index.js
@@ -2366,7 +2366,7 @@ function makeThing(log, config) {
                             }
                         }
                     }
-                    let buttonSvc = new Service.StatelessProgrammableSwitch( name + "_" + i, i + 1 );
+                    let buttonSvc = new Service.StatelessProgrammableSwitch( name + " " + i, i + 1 );
                     characteristic_ProgrammableSwitchEvent(buttonSvc, 'switch' + i, buttonTopic, switchValues, restrictSwitchValues);
                     characteristic_ServiceLabelIndex( buttonSvc, i + 1 );
                     services.push(buttonSvc)


### PR DESCRIPTION
AP-NodeJS WARNING: The accessory 'Virtual Scene Switch_0' has an invalid 'Name' characteristic ('Virtual Scene Switch_0'). Please use only alphanumeric, space, and apostrophe characters. Ensure it starts and ends with an alphabetic or numeric character, and avoid emojis. This may prevent the accessory from being added in the Home App or cause unresponsiveness.