### PR TITLE
Homebridge v2.0 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -1458,7 +1458,9 @@ function makeThing( log, accessoryConfig, api ) {
 
             // Characteristic.OutletInUse
             function characteristic_OutletInUse( service ) {
-                booleanCharacteristic( service, 'outletInUse', Characteristic.OutletInUse, null, config.topics.getInUse );
+                booleanCharacteristic( service, 'outletInUse', Characteristic.OutletInUse, null, config.topics.getInUse, false, function( val ) {
+                    return val ? Characteristic.OutletInUse.IN_USE : Characteristic.OutletInUse.NOT_IN_USE;
+                } );
             }
 
             // Characteristic.Name
@@ -1543,7 +1545,9 @@ function makeThing( log, accessoryConfig, api ) {
 
             // Characteristic.StatusTampered
             function characteristic_StatusTampered( service ) {
-                booleanCharacteristic( service, 'statusTampered', Characteristic.StatusTampered, null, config.topics.getStatusTampered );
+                booleanCharacteristic( service, 'statusTampered', Characteristic.StatusTampered, null, config.topics.getStatusTampered, false, function( val ) {
+                    return val ? Characteristic.StatusTampered.TAMPERED : Characteristic.StatusTampered.NOT_TAMPERED;
+                } );
             }
 
             // Characteristic.AltSensorState to help detecting triggered state with multiple sensors
@@ -1575,7 +1579,9 @@ function makeThing( log, accessoryConfig, api ) {
 
             // Characteristic.StatusLowBattery
             function characteristic_StatusLowBattery( service ) {
-                booleanCharacteristic( service, 'statusLowBattery', Characteristic.StatusLowBattery, null, config.topics.getStatusLowBattery );
+                booleanCharacteristic( service, 'statusLowBattery', Characteristic.StatusLowBattery, null, config.topics.getStatusLowBattery, false, function( val ) {
+                    return val ? Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW : Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL;
+                } );
             }
 
             // Characteristic.OccupancyDetected
@@ -3364,7 +3370,7 @@ function makeThing( log, accessoryConfig, api ) {
                 }
             } else if( configType == 'television' ) {
                 service = new Service.Television( name, subtype );
-                service.isPrimaryService = true;
+                service.setPrimaryService();
                 characteristic_Active( service );
                 service.setCharacteristic( Characteristic.ActiveIdentifier, 0 );
                 service.setCharacteristic( Characteristic.ConfiguredName, name );
@@ -3421,7 +3427,7 @@ function makeThing( log, accessoryConfig, api ) {
                 }
             } else if( config.type == 'irrigationSystem' ) {
                 service = new Service.IrrigationSystem( name, subtype );
-                service.isPrimaryService = true;
+                service.setPrimaryService();
                 if( !config.topics ) {
                     config.topics = {};
                 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "homebridge -P . -U test"
   },
   "engines": {
-    "homebridge": ">=1.11.0 <3.0.0-0",
+    "homebridge": "^1.6.0 || ^2.0.0",
     "node": "^18.12.0 || ^20.10.0 || ^22.11.0 || ^24.12.0"
   },
   "repository": {
@@ -71,7 +71,7 @@
   "homepage": "https://github.com/arachnetech/homebridge-mqttthing#readme",
   "dependencies": {
     "fakegato-history": "^0.6.2",
-    "homebridge-lib": "^7.2.0",
+    "homebridge-lib": "^7.3.2",
     "jsonpath": "^1.1.1",
     "mqtt": "^4.3.2"
   }


### PR DESCRIPTION
With Homebridge v2 shipping HAP-NodeJS v1, several breaking changes landed that affect this plugin. A prior fix (#705) already addressed the `BatteryService` removal. This PR covers the remaining items needed for a "✅" v2 Readiness indicator in the UI.

### Context

Homebridge v2 verifies compatibility by parsing `engines.homebridge` in `package.json`. The existing range `>=1.11.0 <3.0.0-0` includes v2 implicitly but does not match the explicit format the UI looks for (`^1.6.0 || ^2.0.0`), causing a "?" regardless of actual compatibility.

HAP-NodeJS v1 is stricter about characteristic value types. Three `uint8` enum characteristics (`StatusTampered`, `StatusLowBattery`, `OutletInUse`) were passed through `booleanCharacteristic` without a value mapper — they worked by coercion in the old HAP layer but now risk validation warnings or errors.

HAP-NodeJS v1 also deprecated `Accessory.setPrimaryService()` in favour of `Service.setPrimaryService()`. Two services used the older pattern.

`homebridge-lib` needed a bump to a version whose peer dependency explicitly covers v2.

### Tested against

Homebridge v1.11.2 — plugin loads cleanly, green checkmark appears in the v2 Readiness column.